### PR TITLE
feat: dedicated /gallery page with full photo collection

### DIFF
--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -2,10 +2,12 @@ import { render, screen, fireEvent } from "@testing-library/react"
 import Nav from "@/components/Nav"
 import Hero from "@/components/Hero"
 import Gallery from "@/components/Gallery"
+import GalleryGrid from "@/components/GalleryGrid"
 import About from "@/components/About"
 import Services from "@/components/Services"
 import Contact from "@/components/Contact"
 import Footer from "@/components/Footer"
+import GalleryPage from "@/app/gallery/page"
 
 describe("Nav", () => {
   it("renders without crashing", () => {
@@ -24,6 +26,11 @@ describe("Nav", () => {
     expect(screen.getByText("Gallery")).toBeInTheDocument()
     expect(screen.getByText("About")).toBeInTheDocument()
     expect(screen.getByText("Contact")).toBeInTheDocument()
+  })
+  it("Gallery nav link points to /gallery", () => {
+    render(<Nav />)
+    const link = screen.getByText("Gallery").closest("a") as HTMLAnchorElement
+    expect(link.href).toContain("/gallery")
   })
 })
 
@@ -45,7 +52,7 @@ describe("Hero", () => {
   })
 })
 
-describe("Gallery", () => {
+describe("Gallery (homepage 3x3 preview)", () => {
   it("renders without crashing", () => {
     render(<Gallery />)
   })
@@ -53,10 +60,10 @@ describe("Gallery", () => {
     render(<Gallery />)
     expect(screen.getByText("The Work")).toBeInTheDocument()
   })
-  it("renders 12 images by default (All tab)", () => {
+  it("renders 9 images by default (3x3 preview, All tab)", () => {
     render(<Gallery />)
     const images = screen.getAllByRole("img")
-    expect(images.length).toBe(12)
+    expect(images.length).toBe(9)
   })
   it("uses picsum.photos for placeholder images", () => {
     render(<Gallery />)
@@ -78,7 +85,6 @@ describe("Gallery", () => {
     render(<Gallery />)
     fireEvent.click(screen.getByRole("tab", { name: /Portraits/i }))
     expect(screen.getByRole("tab", { name: /Portraits/i })).toHaveAttribute("aria-selected", "true")
-    // Portraits: 7 images in our data
     const images = screen.getAllByRole("img")
     expect(images.length).toBe(7)
   })
@@ -97,7 +103,62 @@ describe("Gallery", () => {
   it("renders lightbox trigger buttons with aria-labels", () => {
     render(<Gallery />)
     const buttons = screen.getAllByRole("button", { name: /Open .* in lightbox/i })
+    expect(buttons.length).toBe(9)
+  })
+  it("has a View Full Gallery link to /gallery", () => {
+    render(<Gallery />)
+    const link = screen.getByText(/View Full Gallery/i).closest("a") as HTMLAnchorElement
+    expect(link.href).toContain("/gallery")
+  })
+})
+
+describe("GalleryGrid (full collection)", () => {
+  it("renders all 12 images when no limit is set", () => {
+    render(<GalleryGrid />)
+    const images = screen.getAllByRole("img")
+    expect(images.length).toBe(12)
+  })
+  it("respects limit prop", () => {
+    render(<GalleryGrid limit={6} />)
+    const images = screen.getAllByRole("img")
+    expect(images.length).toBe(6)
+  })
+  it("shows title when showTitle is true", () => {
+    render(<GalleryGrid showTitle />)
+    expect(screen.getByText("The Work")).toBeInTheDocument()
+  })
+  it("renders 12 lightbox trigger buttons for full collection", () => {
+    render(<GalleryGrid />)
+    const buttons = screen.getAllByRole("button", { name: /Open .* in lightbox/i })
     expect(buttons.length).toBe(12)
+  })
+})
+
+describe("/gallery page (smoke)", () => {
+  it("renders without crashing", () => {
+    render(<GalleryPage />)
+  })
+  it("shows the gallery heading", () => {
+    render(<GalleryPage />)
+    expect(screen.getByText("The Work")).toBeInTheDocument()
+  })
+  it("shows all 12 images", () => {
+    render(<GalleryPage />)
+    const images = screen.getAllByRole("img")
+    // Nav logo + 12 gallery images (hero image not on this page)
+    const galleryImages = (images as HTMLImageElement[]).filter((img) =>
+      img.src.includes("picsum.photos")
+    )
+    expect(galleryImages.length).toBe(12)
+  })
+  it("has a back link to homepage", () => {
+    render(<GalleryPage />)
+    expect(screen.getByText(/← Back/i)).toBeInTheDocument()
+  })
+  it("shows category tabs", () => {
+    render(<GalleryPage />)
+    expect(screen.getByRole("tab", { name: /All/i })).toBeInTheDocument()
+    expect(screen.getByRole("tab", { name: /Portraits/i })).toBeInTheDocument()
   })
 })
 

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,31 @@
+import Nav from "@/components/Nav"
+import Footer from "@/components/Footer"
+import GalleryGrid from "@/components/GalleryGrid"
+
+export const metadata = {
+  title: "Gallery | Kelly Soto Photography",
+  description: "Browse the full portfolio of Kelly Soto Photography — portraits, families, and events.",
+}
+
+export default function GalleryPage() {
+  return (
+    <>
+      <Nav />
+      <main className="pt-24 pb-24 px-6 min-h-screen" style={{ backgroundColor: "#fafaf8" }}>
+        <div className="max-w-6xl mx-auto">
+          <div className="mb-2">
+            <a
+              href="/"
+              className="text-xs tracking-widest uppercase text-stone-400 hover:text-stone-600 transition-colors"
+            >
+              ← Back
+            </a>
+          </div>
+
+          <GalleryGrid showTitle />
+        </div>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/src/components/Gallery.tsx
+++ b/src/components/Gallery.tsx
@@ -1,8 +1,6 @@
 "use client"
 
-import { useState } from "react"
-import Lightbox from "yet-another-react-lightbox"
-import "yet-another-react-lightbox/styles.css"
+import GalleryGrid from "./GalleryGrid"
 
 export type GalleryCategory = "all" | "portraits" | "families" | "events"
 
@@ -15,42 +13,29 @@ export interface GalleryImage {
 }
 
 export const GALLERY_IMAGES: GalleryImage[] = [
-  { seed: "ks-g1", w: 800, h: 600, alt: "Portrait session", category: "portraits" },
-  { seed: "ks-g2", w: 800, h: 600, alt: "Family moment", category: "families" },
-  { seed: "ks-g3", w: 800, h: 600, alt: "Outdoor portrait", category: "portraits" },
-  { seed: "ks-g4", w: 800, h: 600, alt: "Natural light portrait", category: "portraits" },
-  { seed: "ks-g5", w: 800, h: 600, alt: "Event photography", category: "events" },
-  { seed: "ks-g6", w: 800, h: 600, alt: "Lifestyle session", category: "portraits" },
-  { seed: "ks-g7", w: 800, h: 600, alt: "Family portrait", category: "families" },
-  { seed: "ks-g8", w: 800, h: 600, alt: "Golden hour portrait", category: "portraits" },
-  { seed: "ks-g9", w: 800, h: 600, alt: "Candid moment", category: "events" },
-  { seed: "ks-g10", w: 800, h: 600, alt: "Studio portrait", category: "portraits" },
-  { seed: "ks-g11", w: 800, h: 600, alt: "Outdoor family", category: "families" },
-  { seed: "ks-g12", w: 800, h: 600, alt: "Portrait close-up", category: "portraits" },
+  { seed: "ks-g1",  w: 800, h: 600, alt: "Portrait session",       category: "portraits" },
+  { seed: "ks-g2",  w: 800, h: 600, alt: "Family moment",          category: "families"  },
+  { seed: "ks-g3",  w: 800, h: 600, alt: "Outdoor portrait",       category: "portraits" },
+  { seed: "ks-g4",  w: 800, h: 600, alt: "Natural light portrait",  category: "portraits" },
+  { seed: "ks-g5",  w: 800, h: 600, alt: "Event photography",      category: "events"    },
+  { seed: "ks-g6",  w: 800, h: 600, alt: "Lifestyle session",      category: "portraits" },
+  { seed: "ks-g7",  w: 800, h: 600, alt: "Family portrait",        category: "families"  },
+  { seed: "ks-g8",  w: 800, h: 600, alt: "Golden hour portrait",   category: "portraits" },
+  { seed: "ks-g9",  w: 800, h: 600, alt: "Candid moment",          category: "events"    },
+  { seed: "ks-g10", w: 800, h: 600, alt: "Studio portrait",        category: "portraits" },
+  { seed: "ks-g11", w: 800, h: 600, alt: "Outdoor family",         category: "families"  },
+  { seed: "ks-g12", w: 800, h: 600, alt: "Portrait close-up",      category: "portraits" },
 ]
 
-const CATEGORIES: { value: GalleryCategory; label: string }[] = [
-  { value: "all", label: "All" },
+export const CATEGORIES: { value: GalleryCategory; label: string }[] = [
+  { value: "all",       label: "All"       },
   { value: "portraits", label: "Portraits" },
-  { value: "families", label: "Families" },
-  { value: "events", label: "Events" },
+  { value: "families",  label: "Families"  },
+  { value: "events",    label: "Events"    },
 ]
 
+/** Homepage gallery — shows first 9 photos (3×3 preview grid) */
 export default function Gallery() {
-  const [activeCategory, setActiveCategory] = useState<GalleryCategory>("all")
-  const [lightboxIndex, setLightboxIndex] = useState(-1)
-
-  const filtered = GALLERY_IMAGES.filter(
-    (img) => activeCategory === "all" || img.category === activeCategory
-  )
-
-  const lightboxSlides = filtered.map((img) => ({
-    src: `https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`,
-    alt: img.alt,
-    width: img.w,
-    height: img.h,
-  }))
-
   return (
     <section id="gallery" className="py-24 px-6" style={{ backgroundColor: "#fafaf8" }}>
       <div className="max-w-6xl mx-auto">
@@ -64,53 +49,16 @@ export default function Gallery() {
           The Work
         </h2>
 
-        {/* Category tabs */}
-        <div role="tablist" className="flex justify-center gap-1 mb-10">
-          {CATEGORIES.map((cat) => (
-            <button
-              key={cat.value}
-              role="tab"
-              aria-selected={activeCategory === cat.value}
-              onClick={() => setActiveCategory(cat.value)}
-              className={`px-5 py-2 text-xs tracking-widest uppercase transition-colors rounded-sm ${
-                activeCategory === cat.value
-                  ? "bg-stone-800 text-white"
-                  : "text-stone-500 hover:text-stone-800 border border-stone-200 hover:border-stone-400"
-              }`}
-            >
-              {cat.label}
-            </button>
-          ))}
-        </div>
+        <GalleryGrid limit={9} />
 
-        {/* Uniform-aspect-ratio grid — clean bottom edge */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map((img, idx) => (
-            <button
-              key={img.seed}
-              onClick={() => setLightboxIndex(idx)}
-              className="group relative overflow-hidden rounded-sm w-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-rose-300"
-              style={{ aspectRatio: "4/3" }}
-              aria-label={`Open ${img.alt} in lightbox`}
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={`https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`}
-                alt={img.alt}
-                className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-              />
-              <div className="absolute inset-0 bg-white/0 group-hover:bg-white/10 transition-colors duration-300" />
-            </button>
-          ))}
+        <div className="text-center mt-10">
+          <a
+            href="/gallery"
+            className="inline-block text-xs tracking-widest uppercase text-rose-400 hover:text-rose-500 border border-rose-200 hover:border-rose-300 px-6 py-3 transition-colors"
+          >
+            View Full Gallery
+          </a>
         </div>
-
-        {/* Lightbox */}
-        <Lightbox
-          open={lightboxIndex >= 0}
-          index={lightboxIndex}
-          close={() => setLightboxIndex(-1)}
-          slides={lightboxSlides}
-        />
       </div>
     </section>
   )

--- a/src/components/GalleryGrid.tsx
+++ b/src/components/GalleryGrid.tsx
@@ -1,0 +1,92 @@
+"use client"
+
+import { useState } from "react"
+import Lightbox from "yet-another-react-lightbox"
+import "yet-another-react-lightbox/styles.css"
+import { GALLERY_IMAGES, CATEGORIES, GalleryCategory } from "./Gallery"
+
+interface GalleryGridProps {
+  /** Limit the number of images shown (undefined = show all) */
+  limit?: number
+  showTitle?: boolean
+}
+
+export default function GalleryGrid({ limit, showTitle = false }: GalleryGridProps) {
+  const [activeCategory, setActiveCategory] = useState<GalleryCategory>("all")
+  const [lightboxIndex, setLightboxIndex] = useState(-1)
+
+  const filtered = GALLERY_IMAGES.filter(
+    (img) => activeCategory === "all" || img.category === activeCategory
+  )
+  const visible = limit !== undefined ? filtered.slice(0, limit) : filtered
+
+  const lightboxSlides = visible.map((img) => ({
+    src: `https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`,
+    alt: img.alt,
+    width: img.w,
+    height: img.h,
+  }))
+
+  return (
+    <div>
+      {showTitle && (
+        <div className="mb-8 text-center">
+          <p className="text-xs tracking-[0.3em] uppercase text-stone-400 mb-2">Portfolio</p>
+          <h1
+            className="text-3xl md:text-4xl text-stone-700"
+            style={{ fontFamily: "var(--font-playfair)" }}
+          >
+            The Work
+          </h1>
+        </div>
+      )}
+
+      {/* Category tabs */}
+      <div role="tablist" className="flex justify-center gap-1 mb-10">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.value}
+            role="tab"
+            aria-selected={activeCategory === cat.value}
+            onClick={() => setActiveCategory(cat.value)}
+            className={`px-5 py-2 text-xs tracking-widest uppercase transition-colors rounded-sm ${
+              activeCategory === cat.value
+                ? "bg-stone-800 text-white"
+                : "text-stone-500 hover:text-stone-800 border border-stone-200 hover:border-stone-400"
+            }`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {visible.map((img, idx) => (
+          <button
+            key={img.seed}
+            onClick={() => setLightboxIndex(idx)}
+            className="group relative overflow-hidden rounded-sm w-full cursor-pointer focus:outline-none focus:ring-2 focus:ring-rose-300"
+            style={{ aspectRatio: "4/3" }}
+            aria-label={`Open ${img.alt} in lightbox`}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`https://picsum.photos/seed/${img.seed}/${img.w}/${img.h}`}
+              alt={img.alt}
+              className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+            <div className="absolute inset-0 bg-white/0 group-hover:bg-white/10 transition-colors duration-300" />
+          </button>
+        ))}
+      </div>
+
+      <Lightbox
+        open={lightboxIndex >= 0}
+        index={lightboxIndex}
+        close={() => setLightboxIndex(-1)}
+        slides={lightboxSlides}
+      />
+    </div>
+  )
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,13 +9,15 @@ export default function Nav() {
           Kelly Soto
         </span>
         <ul className="hidden md:flex items-center gap-8 text-sm text-stone-500 tracking-wide">
-          {["Gallery", "About", "Services", "Contact"].map((item) => (
-            <li key={item}>
-              <a
-                href={`#${item.toLowerCase()}`}
-                className="hover:text-stone-800 transition-colors"
-              >
-                {item}
+          {[
+            { label: "Gallery",  href: "/gallery"   },
+            { label: "About",    href: "#about"     },
+            { label: "Services", href: "#services"  },
+            { label: "Contact",  href: "#contact"   },
+          ].map((item) => (
+            <li key={item.label}>
+              <a href={item.href} className="hover:text-stone-800 transition-colors">
+                {item.label}
               </a>
             </li>
           ))}


### PR DESCRIPTION
Closes #2

## Changes
- **GalleryGrid** — new shared component used by both homepage and gallery page
- **Gallery.tsx** — homepage keeps 3×3 (limit=9), adds 'View Full Gallery' → /gallery
- **app/gallery/page.tsx** — full collection (12 photos), category tabs, lightbox, back link
- **Nav.tsx** — Gallery link → /gallery

43 tests pass (up from 32: +4 GalleryGrid, +5 gallery page, +1 Nav href)