### PR TITLE
feat: logo links to /, contact form wired to Formspree

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,5 @@
+# Formspree form ID — get this from https://formspree.io/forms
+# 1. Create a free account at formspree.io
+# 2. Create a new form, set the email to Kelly's address
+# 3. Copy the form ID (looks like "xvgojrzk") and set it here
+NEXT_PUBLIC_FORMSPREE_ID=YOUR_FORM_ID

--- a/src/__tests__/components.test.tsx
+++ b/src/__tests__/components.test.tsx
@@ -32,6 +32,12 @@ describe("Nav", () => {
     const link = screen.getByText("Gallery").closest("a") as HTMLAnchorElement
     expect(link.href).toContain("/gallery")
   })
+  it("logo is a link to /", () => {
+    render(<Nav />)
+    const logo = screen.getByText("Kelly Soto").closest("a") as HTMLAnchorElement
+    expect(logo).not.toBeNull()
+    expect(logo.href).toContain("/")
+  })
 })
 
 describe("Hero", () => {
@@ -213,6 +219,16 @@ describe("Contact", () => {
   it("has a submit button", () => {
     render(<Contact />)
     expect(screen.getByRole("button", { name: /Send Message/i })).toBeInTheDocument()
+  })
+  it("submit button is enabled by default", () => {
+    render(<Contact />)
+    expect(screen.getByRole("button", { name: /Send Message/i })).not.toBeDisabled()
+  })
+  it("name input is controlled", () => {
+    render(<Contact />)
+    const input = screen.getByPlaceholderText("Your name") as HTMLInputElement
+    fireEvent.change(input, { target: { value: "Kelly" } })
+    expect(input.value).toBe("Kelly")
   })
 })
 

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,6 +1,39 @@
 "use client"
 
+import { useState } from "react"
+
+type FormStatus = "idle" | "submitting" | "success" | "error"
+
+const FORMSPREE_ID = process.env.NEXT_PUBLIC_FORMSPREE_ID ?? "YOUR_FORM_ID"
+
 export default function Contact() {
+  const [name, setName]       = useState("")
+  const [email, setEmail]     = useState("")
+  const [message, setMessage] = useState("")
+  const [status, setStatus]   = useState<FormStatus>("idle")
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus("submitting")
+    try {
+      const res = await fetch(`https://formspree.io/f/${FORMSPREE_ID}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ name, email, message }),
+      })
+      if (res.ok) {
+        setStatus("success")
+        setName("")
+        setEmail("")
+        setMessage("")
+      } else {
+        setStatus("error")
+      }
+    } catch {
+      setStatus("error")
+    }
+  }
+
   return (
     <section id="contact" className="py-24 px-6 bg-white">
       <div className="max-w-xl mx-auto">
@@ -18,45 +51,75 @@ export default function Contact() {
           or you&apos;re just starting to dream it up, reach out and let&apos;s talk.
         </p>
 
-        {/* Form — UI only, no backend */}
-        <form className="space-y-5" onSubmit={(e) => e.preventDefault()}>
-          <div>
-            <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
-              Name
-            </label>
-            <input
-              type="text"
-              placeholder="Your name"
-              className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm"
-            />
+        {status === "success" ? (
+          <div className="text-center py-12">
+            <p
+              className="text-2xl text-stone-700 mb-3"
+              style={{ fontFamily: "var(--font-playfair)" }}
+            >
+              Message sent!
+            </p>
+            <p className="text-stone-500 text-sm">
+              Thank you — I&apos;ll be in touch soon.
+            </p>
           </div>
-          <div>
-            <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
-              Email
-            </label>
-            <input
-              type="email"
-              placeholder="your@email.com"
-              className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm"
-            />
-          </div>
-          <div>
-            <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
-              Message
-            </label>
-            <textarea
-              rows={5}
-              placeholder="Tell me about your session..."
-              className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm resize-none"
-            />
-          </div>
-          <button
-            type="submit"
-            className="w-full py-3 text-xs tracking-widest uppercase text-white bg-rose-300 hover:bg-rose-400 transition-colors rounded-sm"
-          >
-            Send Message
-          </button>
-        </form>
+        ) : (
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div>
+              <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
+                Name
+              </label>
+              <input
+                type="text"
+                placeholder="Your name"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
+                Email
+              </label>
+              <input
+                type="email"
+                placeholder="your@email.com"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm"
+              />
+            </div>
+            <div>
+              <label className="block text-xs tracking-widest uppercase text-stone-400 mb-1.5">
+                Message
+              </label>
+              <textarea
+                rows={5}
+                placeholder="Tell me about your session..."
+                required
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                className="w-full border border-stone-200 rounded-sm px-4 py-3 text-stone-700 placeholder-stone-300 focus:outline-none focus:border-rose-200 bg-white text-sm resize-none"
+              />
+            </div>
+
+            {status === "error" && (
+              <p className="text-xs text-rose-500 text-center">
+                Something went wrong — please try again or email directly.
+              </p>
+            )}
+
+            <button
+              type="submit"
+              disabled={status === "submitting"}
+              className="w-full py-3 text-xs tracking-widest uppercase text-white bg-rose-300 hover:bg-rose-400 disabled:opacity-60 transition-colors rounded-sm"
+            >
+              {status === "submitting" ? "Sending…" : "Send Message"}
+            </button>
+          </form>
+        )}
       </div>
     </section>
   )

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,12 +2,13 @@ export default function Nav() {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-sm border-b border-stone-100">
       <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
-        <span
-          className="text-xl tracking-widest text-stone-700"
+        <a
+          href="/"
+          className="text-xl tracking-widest text-stone-700 hover:text-stone-900 transition-colors"
           style={{ fontFamily: "var(--font-playfair)" }}
         >
           Kelly Soto
-        </span>
+        </a>
         <ul className="hidden md:flex items-center gap-8 text-sm text-stone-500 tracking-wide">
           {[
             { label: "Gallery",  href: "/gallery"   },


### PR DESCRIPTION
Closes #4

- **Nav**: logo → `<a href='/'>`
- **Contact**: Formspree integration via `NEXT_PUBLIC_FORMSPREE_ID` env var; success/error/submitting states
- **.env.local.example**: setup instructions

**George** — activate by: go to formspree.io → create form with Kelly's email → copy the ID → set `NEXT_PUBLIC_FORMSPREE_ID=<id>` in Vercel env vars.

46 tests pass